### PR TITLE
Replace getEntityName() inside queries with direct names

### DIFF
--- a/data/src/main/java/pl/atins/sos/data/dao/impl/AbstractCrudDao.java
+++ b/data/src/main/java/pl/atins/sos/data/dao/impl/AbstractCrudDao.java
@@ -71,8 +71,4 @@ public abstract class AbstractCrudDao<T extends BaseEntity> implements CrudDao<T
     public void deleteById(long id) {
         findById(id).ifPresent(this::delete);
     }
-
-    protected String getEntityName() {
-        return entityName;
-    }
 }

--- a/data/src/main/java/pl/atins/sos/data/dao/impl/ClassDaoImpl.java
+++ b/data/src/main/java/pl/atins/sos/data/dao/impl/ClassDaoImpl.java
@@ -17,7 +17,7 @@ public class ClassDaoImpl extends AbstractCrudDao<UniversityClass> implements Cl
 
     @Override
     public List<UniversityClass> findBySubjectId(long subjectId) {
-        Query query = em.createQuery("FROM " + getEntityName() + " class where class.subject.id = :id");
+        Query query = em.createQuery("FROM UniversityClass class where class.subject.id = :id");
         query.setParameter("id", subjectId);
         return query.getResultList();
     }

--- a/data/src/main/java/pl/atins/sos/data/dao/impl/EnrollmentDaoImpl.java
+++ b/data/src/main/java/pl/atins/sos/data/dao/impl/EnrollmentDaoImpl.java
@@ -14,7 +14,7 @@ public class EnrollmentDaoImpl extends AbstractCrudDao<Enrollment> implements En
     @Override
     public void unregisterStudentFromSubject(long studentId, long subjectId) {
         QueryUtils.runDirectQuerySafely(em, () -> {
-            Query query = em.createQuery("DELETE FROM " + getEntityName() + " e"
+            Query query = em.createQuery("DELETE FROM Enrollment e"
                     + " WHERE e.subject.id = :subjectId AND e.student.id = :studentId");
             query.setParameter("subjectId", subjectId);
             query.setParameter("studentId", studentId);
@@ -24,7 +24,7 @@ public class EnrollmentDaoImpl extends AbstractCrudDao<Enrollment> implements En
 
     @Override
     public List<Enrollment> findByStudentId(long studentId) {
-        Query query = em.createQuery("FROM " + getEntityName() + " e where e.student.id = :id");
+        Query query = em.createQuery("FROM Enrollment e where e.student.id = :id");
         query.setParameter("id", studentId);
         return query.getResultList();
     }


### PR DESCRIPTION
It has been decided that direct names inside queries increase readability and since there's no full reflection of class fields, direct names for entities maintain consistency